### PR TITLE
fix: default atom 변수 추가 및 캔버스 언마운트시 초기화 실행

### DIFF
--- a/src/atoms/canvas.ts
+++ b/src/atoms/canvas.ts
@@ -8,7 +8,7 @@ import {
 } from "@/constants/common";
 import { CanvasAtom, OCRAtom } from "@/types/canvas";
 
-export const canvasAtom = atom<CanvasAtom>({
+export const defaultCavnasAtom = {
   width: 0,
   height: 0,
   scale: {
@@ -25,13 +25,16 @@ export const canvasAtom = atom<CanvasAtom>({
   items: [],
   blocks: [],
   newRectangle: null,
-});
+};
 
-export const ocrAtom = atom<OCRAtom>({
+export const defaultOCRAtom = {
   isProcessing: false,
   isExectued: false,
   data: [],
-});
+};
+
+export const canvasAtom = atom<CanvasAtom>(defaultCavnasAtom);
+export const ocrAtom = atom<OCRAtom>(defaultOCRAtom);
 
 export const displayScaleAtom = atom((get) => {
   const canvas = get(canvasAtom);

--- a/src/atoms/effects.ts
+++ b/src/atoms/effects.ts
@@ -1,8 +1,8 @@
 import { atomEffect } from "jotai-effect";
 import { toast } from "@/hooks/useToast";
-import { imageAtom } from "./image";
+import { defaultImageAtom, imageAtom } from "./image";
 import { calculateCanvasSize } from "@/lib/canvas";
-import { canvasAtom, displayScaleAtom, ocrAtom } from "./canvas";
+import { canvasAtom, defaultCavnasAtom, defaultOCRAtom, displayScaleAtom, ocrAtom } from "./canvas";
 import { createWorker, PSM } from "tesseract.js";
 import { v4 as uuidv4 } from "uuid";
 import {
@@ -175,4 +175,18 @@ export const wheelZoomCanvasEffectAtom = atomEffect((get, set) => {
 
   window.addEventListener("wheel", wheelZoom, { passive: false });
   return () => window.removeEventListener("wheel", wheelZoom);
+});
+
+export const clearOnUnmount = atomEffect((get, set) => {
+  const image = get(imageAtom);
+
+  return () => {
+    if (image.element && image.url) {
+      URL.revokeObjectURL(image.url);
+
+      set(imageAtom, defaultImageAtom);
+      set(canvasAtom, defaultCavnasAtom);
+      set(ocrAtom, defaultOCRAtom);
+    }
+  };
 });

--- a/src/atoms/image.ts
+++ b/src/atoms/image.ts
@@ -2,9 +2,11 @@ import { atom } from "jotai";
 import { DEFAULT_IMAGE_NAME } from "@/constants/common";
 import { ImageAtom } from "@/types/canvas";
 
-export const imageAtom = atom<ImageAtom>({
+export const defaultImageAtom = {
   url: null,
   type: null,
   name: DEFAULT_IMAGE_NAME,
   element: null,
-});
+};
+
+export const imageAtom = atom<ImageAtom>(defaultImageAtom);

--- a/src/layouts/AppCanvas.tsx
+++ b/src/layouts/AppCanvas.tsx
@@ -4,6 +4,7 @@ import {
   outsideCanvasClickEffectAtom,
   responsiveScaleAtom,
   wheelZoomCanvasEffectAtom,
+  clearOnUnmount,
 } from "@/atoms/effects";
 import { imageAtom } from "@/atoms/image";
 import { Canvas, Upload } from "@/components/Canvas";
@@ -18,6 +19,7 @@ export function AppCanvas() {
   useAtom(ocrEffectAtom);
   useAtom(outsideCanvasClickEffectAtom);
   useAtom(wheelZoomCanvasEffectAtom);
+  useAtom(clearOnUnmount);
 
   return !image.url ? <Upload /> : <Canvas />;
 }


### PR DESCRIPTION
## 이슈

- close #37

## 작업 내용
- canvas 컴포넌트 언마운트시 atom 초기화 작업
- image url 미리보기도 revoke 시킴